### PR TITLE
Makes the consumer class available to middlewares during message processin

### DIFF
--- a/lib/lepus/consumer.rb
+++ b/lib/lepus/consumer.rb
@@ -99,6 +99,7 @@ module Lepus
     # @raise [InvalidConsumerReturnError] if you return something other than +:ack+, +:reject+ or +:requeue+ from {#perform}.
     def process_delivery(delivery_info, metadata, payload)
       message = Message.new(delivery_info, metadata, payload)
+      message.consumer_class = self.class
       self
         .class
         .middlewares

--- a/lib/lepus/message.rb
+++ b/lib/lepus/message.rb
@@ -3,6 +3,7 @@
 module Lepus
   class Message
     attr_reader :delivery_info, :metadata, :payload
+    attr_accessor :consumer_class
 
     def initialize(delivery_info, metadata, payload)
       @delivery_info = delivery_info
@@ -10,12 +11,14 @@ module Lepus
       @payload = payload
     end
 
-    def mutate(payload: nil, metadata: nil, delivery_info: nil)
+    def mutate(payload: nil, metadata: nil, delivery_info: nil, consumer_class: nil)
       self.class.new(
         delivery_info || @delivery_info,
         metadata || @metadata,
         payload || @payload
-      )
+      ).tap do |message|
+        message.consumer_class = consumer_class || @consumer_class
+      end
     end
 
     def to_h

--- a/lib/lepus/middlewares/honeybadger.rb
+++ b/lib/lepus/middlewares/honeybadger.rb
@@ -15,16 +15,17 @@ module Lepus
       def call(message, app)
         app.call(message)
       rescue => err
-        ::Honeybadger.notify(err, context: context)
+        ::Honeybadger.notify(err, context: context(message))
         raise err
       end
 
       private
 
-      def context
-        return {} unless @class_name
+      def context(message)
+        return {class_name: @class_name} if @class_name
+        return {class_name: message.consumer_class.name} if message.consumer_class
 
-        {class_name: @class_name}
+        {}
       end
     end
   end

--- a/spec/lepus/consumer_spec.rb
+++ b/spec/lepus/consumer_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe Lepus::Consumer do
       instance.process_delivery(delivery_info, metadata, payload)
     end
 
+    it "sets the consumer_class on the message" do
+      received_message = nil
+      allow(instance).to receive(:perform) do |message|
+        received_message = message
+        :ack
+      end
+
+      instance.process_delivery(delivery_info, metadata, payload)
+
+      expect(received_message.consumer_class).to eq(instance.class)
+    end
+
     it "returns the result of #perform" do
       allow(instance).to receive(:perform).and_return(:ack)
 

--- a/spec/lepus/message_spec.rb
+++ b/spec/lepus/message_spec.rb
@@ -8,6 +8,45 @@ RSpec.describe Lepus::Message do
   let(:payload) { {key: "value"} }
   let(:message) { described_class.new(delivery_info, metadata, payload) }
 
+  describe "#consumer_class" do
+    it "can be set and retrieved" do
+      consumer_class = Class.new
+      message.consumer_class = consumer_class
+      expect(message.consumer_class).to eq(consumer_class)
+    end
+
+    it "defaults to nil" do
+      expect(message.consumer_class).to be_nil
+    end
+  end
+
+  describe "#mutate" do
+    let(:consumer_class) { Class.new }
+
+    before do
+      message.consumer_class = consumer_class
+    end
+
+    it "preserves consumer_class when no new value is provided" do
+      mutated_message = message.mutate(payload: "new payload")
+      expect(mutated_message.consumer_class).to eq(consumer_class)
+      expect(mutated_message.payload).to eq("new payload")
+    end
+
+    it "allows overriding consumer_class" do
+      new_consumer_class = Class.new
+      mutated_message = message.mutate(consumer_class: new_consumer_class)
+      expect(mutated_message.consumer_class).to eq(new_consumer_class)
+    end
+
+    it "preserves other attributes when mutating consumer_class" do
+      mutated_message = message.mutate(consumer_class: Class.new)
+      expect(mutated_message.delivery_info).to eq(delivery_info)
+      expect(mutated_message.metadata).to eq(metadata)
+      expect(mutated_message.payload).to eq(payload)
+    end
+  end
+
   describe "#to_h" do
     subject(:msg) { message.to_h }
 

--- a/spec/lepus/middlewares/honeybadger_spec.rb
+++ b/spec/lepus/middlewares/honeybadger_spec.rb
@@ -41,4 +41,42 @@ RSpec.describe Lepus::Middlewares::Honeybadger do
       )
     end.to raise_error(error)
   end
+
+  context "when no class_name is provided" do
+    let(:middleware) { described_class.new }
+    let(:consumer_class) { Class.new }
+
+    before do
+      message.consumer_class = consumer_class
+      allow(consumer_class).to receive(:name).and_return("TestConsumer")
+    end
+
+    it "uses consumer_class name as fallback" do
+      error = RuntimeError.new("moep")
+      expect(honeybadger).to receive(:notify).with(error, context: {class_name: "TestConsumer"})
+
+      expect do
+        middleware.call(
+          message,
+          proc { raise error }
+        )
+      end.to raise_error(error)
+    end
+  end
+
+  context "when no class_name and no consumer_class" do
+    let(:middleware) { described_class.new }
+
+    it "uses empty context" do
+      error = RuntimeError.new("moep")
+      expect(honeybadger).to receive(:notify).with(error, context: {})
+
+      expect do
+        middleware.call(
+          message,
+          proc { raise error }
+        )
+      end.to raise_error(error)
+    end
+  end
 end

--- a/spec/lepus/middlewares/json_spec.rb
+++ b/spec/lepus/middlewares/json_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe Lepus::Middlewares::JSON do
       expect(received_message.metadata).to equal(metadata)
     end
 
+    it "preserves consumer_class when forwarding the message" do
+      consumer_class = Class.new
+      message.consumer_class = consumer_class
+      received_message = nil
+
+      middleware.call(message, proc { |msg, _blk|
+                                 received_message = msg
+                                 :ok
+                               })
+
+      expect(received_message.consumer_class).to equal(consumer_class)
+    end
+
     it "can optionally symbolize keys" do
       middleware =
         described_class.new(


### PR DESCRIPTION
## Add consumer class context to middlewares

### Summary
Makes the consumer class available to middlewares during message processing, enabling better error tracking and context-aware middleware behavior.

### Changes
- **Message**: Added `consumer_class` attribute and updated `mutate` method to preserve it
- **Consumer**: Sets `consumer_class` on message during `process_delivery`
- **Honeybadger middleware**: Added fallback to use `message.consumer_class.name` when no explicit `class_name` is provided

### Benefits
- Middlewares can now access which consumer is processing the message
- Honeybadger middleware automatically uses consumer class name for better error tracking
- No breaking changes to existing middleware APIs
- Consumer context flows through the entire middleware chain

### Example
```ruby
# Before: Honeybadger only worked with explicit class_name
use :honeybadger, class_name: "MyConsumer"

# After: Automatically uses consumer class as fallback
use :honeybadger  # Uses message.consumer_class.name automatically
```