### PR TITLE
docs: add comprehensive documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,80 @@
+# lepus
+
+RabbitMQ-backed producer/consumer framework for Ruby — with a supervisor, middleware chains, a CLI, and a live web dashboard.
+
+Think Sidekiq or SolidQueue, but on top of RabbitMQ rather than Redis or a database. Lepus handles the operational concerns (process supervision, graceful shutdown, connection pooling, signal handling, per-worker pools) so your application code can stay focused on "what does this message do".
+
+## Contents
+
+- [Getting started](getting-started.md) — install, define your first consumer and producer, run them
+- [Configuration](configuration.md) — the full `Lepus.configure` DSL
+- [Consumers](consumers.md) — queue bindings, lifecycle, result codes, retries
+- [Producers](producers.md) — exchanges, publishing, enable/disable hooks
+- [Middleware](middleware.md) — built-in middlewares and how to write your own
+- [CLI](cli.md) — `lepus start`, `lepus web`
+- [Supervisor](supervisor.md) — process model, signals, graceful shutdown
+- [Web dashboard](web.md) — the monitoring UI
+- [Testing](testing.md) — testing consumers and producers
+- [Rails integration](rails.md) — Railtie, executor wrapping, Puma plugin
+
+## Install
+
+```ruby
+# Gemfile
+gem 'lepus'
+```
+
+## One-minute tour
+
+```ruby
+# config/initializers/lepus.rb
+Lepus.configure do |config|
+  config.rabbitmq_url   = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+  config.connection_name = 'my-service'
+end
+
+# app/consumers/orders_consumer.rb
+class OrdersConsumer < Lepus::Consumer
+  configure(
+    queue:       'orders',
+    exchange:    { name: 'orders', type: :topic, durable: true },
+    routing_key: ['order.*']
+  )
+
+  use :json, symbolize_keys: true
+  use :max_retry, retries: 5
+
+  def perform(message)
+    Order.create!(message.payload)
+    :ack
+  end
+end
+
+# app/producers/orders_producer.rb
+class OrdersProducer < Lepus::Producer
+  configure(exchange: { name: 'orders', type: :topic, durable: true })
+  use :json
+  use :correlation_id
+end
+```
+
+Run the consumer:
+
+```bash
+bundle exec lepus start OrdersConsumer
+```
+
+Publish from anywhere in your app:
+
+```ruby
+OrdersProducer.publish({ order_id: 42, total: 99.99 }, routing_key: 'order.created')
+```
+
+## Version & dependencies
+
+- Ruby: `>= 2.7.0`
+- Runtime: `bunny`, `thor`, `zeitwerk`, `concurrent-ruby`, `multi_json`
+
+## License
+
+MIT.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,108 @@
+# CLI
+
+The `lepus` executable is the main operational entry point. It's a Thor-based CLI with two subcommands.
+
+```bash
+bundle exec lepus <command> [args] [options]
+```
+
+## `lepus start`
+
+Boot the supervisor and run the specified consumers.
+
+```bash
+bundle exec lepus start [CONSUMER_CLASSES...] [options]
+```
+
+If no classes are specified **and** `config.consumers_directory` is set, every consumer class discovered in that directory is started.
+
+### Options
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--debug` | `false` | Set logger level to DEBUG. |
+| `--logfile PATH` | stdout | Write logs to a file. |
+| `--pidfile PATH` | none | Write the supervisor PID to a file. |
+| `--require_file PATH`, `-r PATH` | none | Require this file before starting (e.g. `config/environment.rb`). |
+
+### Examples
+
+```bash
+# One consumer, no framework auto-load
+bundle exec lepus start OrdersConsumer
+
+# Multiple consumers, Rails env loaded first
+bundle exec lepus start OrdersConsumer PaymentsConsumer \
+  --require_file config/environment.rb
+
+# Auto-load everything under config.consumers_directory
+bundle exec lepus start
+
+# Debug mode + pidfile (typical for a systemd unit)
+bundle exec lepus start OrdersConsumer \
+  --require_file config/environment.rb \
+  --pidfile /var/run/lepus.pid \
+  --logfile /var/log/lepus.log \
+  --debug
+```
+
+### What happens at start
+
+1. Load `--require_file` if given.
+2. Resolve consumer classes (CLI args or auto-discovered).
+3. Group consumers by their `process.name` (defaulting to `:default`).
+4. Fork one worker subprocess per group. Parent becomes the supervisor.
+5. Each worker opens a Bunny channel, declares queues/exchanges/bindings, and starts consuming with its configured thread pool.
+6. Supervisor monitors children via pipes and restarts any that crash.
+
+See [supervisor.md](supervisor.md) for the full lifecycle.
+
+## `lepus web`
+
+Run the web dashboard.
+
+```bash
+bundle exec lepus web [options]
+```
+
+### Options
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--port PORT`, `-p PORT` | `9292` | Port to bind. |
+| `--host HOST`, `-o HOST` | `0.0.0.0` | Host to bind. |
+
+### Example
+
+```bash
+bundle exec lepus web --port 9292 --host 0.0.0.0
+```
+
+Visit http://localhost:9292.
+
+The web UI reads from the process registry backend (`config.process_registry_backend`). For multi-host visibility, set the backend to `:rabbitmq`. See [web.md](web.md).
+
+### Mounting in Rails
+
+Instead of running the CLI, you can mount the web app directly:
+
+```ruby
+# config/routes.rb
+require 'lepus/web'
+mount Lepus::Web::App, at: '/lepus'
+```
+
+See [rails.md](rails.md) for authorization patterns.
+
+## Exit codes
+
+- `0` — graceful shutdown (SIGTERM / SIGINT).
+- Non-zero — unrecoverable error at boot (config invalid, RabbitMQ unreachable, etc.).
+
+Workers that crash after boot are restarted by the supervisor; the supervisor itself only exits on an unrecoverable event or a requested shutdown.
+
+## Environment variables
+
+- `RABBITMQ_URL` — fallback for `config.rabbitmq_url` if not explicitly set.
+
+Everything else is configured via `Lepus.configure`. See [configuration.md](configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,171 @@
+# Configuration
+
+Lepus is configured via a single block:
+
+```ruby
+Lepus.configure do |config|
+  # ... see below ...
+end
+```
+
+The configuration is mutable at boot and should be set once. Values are read lazily — most only matter at worker-start time.
+
+## Connection
+
+```ruby
+Lepus.configure do |config|
+  config.rabbitmq_url                    = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+  config.connection_name                 = 'my-service'
+  config.recovery_attempts               = 10          # nil = infinite
+  config.recover_from_connection_close   = true
+end
+```
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `rabbitmq_url` | `ENV['RABBITMQ_URL']` or `amqp://guest:guest@localhost:5672` | Connection string |
+| `connection_name` | gem-generated | Shown in RabbitMQ management UI — set to your service name |
+| `recovery_attempts` | `10` | Max automatic reconnects; `nil` for infinite |
+| `recover_from_connection_close` | `true` | Auto-recover after a clean close |
+
+## Application metadata
+
+```ruby
+config.application_name       = 'orders-service'
+config.management_api_url     = 'http://rabbitmq:15672'   # only for :rabbitmq registry backend
+```
+
+Shown in the web dashboard. `management_api_url` is only required if `process_registry_backend = :rabbitmq`.
+
+## Consumer discovery
+
+```ruby
+config.consumers_directory = 'app/consumers'
+```
+
+When present, `lepus start` with no class arguments auto-loads every class under this directory and runs all configured consumers.
+
+## Worker pools
+
+A **worker** is a subprocess the supervisor forks. Consumers are grouped into workers by their `process.name`.
+
+```ruby
+config.worker(:default) do |w|
+  w.pool_size    = 5       # threads per worker
+  w.pool_timeout = 10.0    # seconds before yielding to another task
+
+  w.before_fork { ActiveRecord::Base.connection_handler.clear_all_connections! }
+  w.after_fork  { ActiveRecord::Base.establish_connection }
+end
+
+config.worker(:high_priority, pool_size: 10)
+```
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `pool_size` | `2` | Max threads per worker process |
+| `pool_timeout` | `10.0` | Seconds threads wait on queue checkout |
+| `before_fork` | no-op | Block run in parent before fork — close sockets, drop DB connections, etc. |
+| `after_fork` | no-op | Block run in child after fork — reconnect, reseed RNG, etc. |
+
+Assign consumers to a named worker via their own `configure(process: { name: :high_priority })` (see [consumers.md](consumers.md)).
+
+## Producer pool
+
+Producers share a connection pool:
+
+```ruby
+config.producer do |p|
+  p.pool_size    = 5
+  p.pool_timeout = 5.0
+end
+```
+
+## Global middleware
+
+Middleware chains run around every message published or consumed, in addition to any per-producer or per-consumer `use` calls.
+
+```ruby
+config.producer_middlewares do |chain|
+  chain.use :instrumentation
+  chain.use :correlation_id
+end
+
+config.consumer_middlewares do |chain|
+  chain.use :json, symbolize_keys: true
+end
+```
+
+See [middleware.md](middleware.md).
+
+## Process registry
+
+The supervisor keeps a registry of running processes, visible to the web dashboard.
+
+```ruby
+config.process_registry_backend     = :file      # or :rabbitmq
+config.process_heartbeat_interval   = 60         # seconds
+config.process_alive_threshold      = 5 * 60     # seconds
+```
+
+- `:file` — metadata in local files under `/tmp/lepus/...`. Single-host.
+- `:rabbitmq` — metadata in RabbitMQ itself; multi-host visibility in the web dashboard.
+
+## Rails integration
+
+When Rails is loaded, a Railtie wires:
+
+- `config.app_executor = Rails.application.executor` automatically
+- `config.logger = Rails.logger`
+
+You can override either:
+
+```ruby
+config.app_executor = nil             # disable executor wrapping
+config.logger       = MyLogger.new
+```
+
+See [rails.md](rails.md).
+
+## Threading error handler
+
+```ruby
+config.on_thread_error = ->(exception) {
+  Rails.error.report(exception)
+  Honeybadger.notify(exception)
+}
+```
+
+Called when a worker thread raises. Does not stop the worker.
+
+## Logger
+
+```ruby
+config.logger = Logger.new($stdout)
+```
+
+Default: `Logger.new($stdout)` (or `Rails.logger` if Rails is present). The `--debug` CLI flag sets the level to DEBUG.
+
+## Full example
+
+```ruby
+Lepus.configure do |config|
+  config.rabbitmq_url    = ENV.fetch('RABBITMQ_URL')
+  config.connection_name = 'orders-service'
+  config.application_name = 'orders-service'
+  config.consumers_directory = 'app/consumers'
+
+  config.worker(:default) do |w|
+    w.pool_size = 5
+    w.before_fork { ActiveRecord::Base.connection_handler.clear_all_connections! }
+    w.after_fork  { ActiveRecord::Base.establish_connection }
+  end
+
+  config.producer_middlewares do |chain|
+    chain.use :instrumentation
+    chain.use :correlation_id
+  end
+
+  config.on_thread_error = ->(exc) { Honeybadger.notify(exc) }
+end
+```

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -1,0 +1,168 @@
+# Consumers
+
+Consumers subscribe to a queue, receive messages, and process them. A consumer is a subclass of `Lepus::Consumer` with a `configure` call and a `perform` method.
+
+## Minimal example
+
+```ruby
+class OrdersConsumer < Lepus::Consumer
+  configure(
+    queue:    'orders',
+    exchange: { name: 'orders', type: :topic, durable: true },
+    routing_key: ['order.*']
+  )
+
+  use :json, symbolize_keys: true
+
+  def perform(message)
+    Order.create!(message.payload)
+    :ack
+  end
+end
+```
+
+## `configure` DSL
+
+```ruby
+configure(
+  queue:       'orders',                                    # string or hash
+  exchange:    { name: 'orders', type: :topic, durable: true },
+  routing_key: ['order.*', 'invoice.created'],              # array or string
+  prefetch:    1,                                            # channel QoS
+  retry_queue: { delay: 5_000 },                            # or true, or false
+  error_queue: true,                                         # or queue name, or false
+  process:     { name: :default, threads: 5 },              # worker assignment
+  channel:     { pool_size: 1, shutdown_timeout: 60, abort_on_exception: false }
+)
+```
+
+| Key | Purpose |
+|-----|---------|
+| `queue` | The queue name — string, or a hash for advanced options (`name`, `durable`, `arguments`, …). |
+| `exchange` | Bind to this exchange. String, or hash (`name`, `type`, `durable`, `auto_delete`). |
+| `routing_key` | Binding routing key(s). |
+| `prefetch` | Channel QoS (`basic.qos`). Leave at `1` unless you know you need more. |
+| `retry_queue` | When truthy, sets up a retry queue with a delay exchange. Messages requeued via `:requeue` or `max_retry` go here. |
+| `error_queue` | Queue name (string) or `true` to auto-name. Messages that exhaust retries land here. |
+| `process.name` | The named worker pool this consumer runs in — see `Lepus.configure.worker(:name)`. |
+| `process.threads` | Threads inside the consumer's worker dedicated to this consumer. |
+
+## The `perform` method
+
+```ruby
+def perform(message)
+  # ...
+end
+```
+
+`message` is a `Lepus::Message` with:
+
+- `#payload` — the decoded body (raw bytes, or parsed data if a decoding middleware is in the chain).
+- `#delivery_info` — `#exchange`, `#routing_key`, `#redelivered?`, `#delivery_tag`, `#consumer_tag`.
+- `#metadata` — `#headers`, `#content_type`, `#content_encoding`, `#correlation_id`, `#message_id`, `#reply_to`, `#type`, `#timestamp`, `#user_id`, `#app_id`, `#priority`.
+
+Return a disposition symbol or call one of the helpers:
+
+| Return | Helper | Effect |
+|--------|--------|--------|
+| `:ack` | `ack!` | Acknowledge the message. |
+| `:reject` | `reject!` | Reject without requeue (drops, or goes to DLX if configured). |
+| `:requeue` | `requeue!` | Reject with requeue — back of the queue. |
+| `:nack` | `nack!` | Negative-ack. |
+
+A `perform` that returns nothing implicitly acks. A `perform` that raises is logged, `on_thread_error` fires, and the message is rejected.
+
+## Middleware
+
+Add middlewares to a consumer with `use`:
+
+```ruby
+class OrdersConsumer < Lepus::Consumer
+  use :json, symbolize_keys: true
+  use :max_retry, retries: 5, error_queue: 'orders.error'
+  use :exception_logger
+  use :honeybadger
+end
+```
+
+Built-in middlewares:
+
+| Name | Purpose |
+|------|---------|
+| `:json` | Parse JSON body into a hash. |
+| `:max_retry` | Track `x-death` headers; after N retries, route to error queue. |
+| `:exception_logger` | Log unhandled exceptions with backtrace. |
+| `:honeybadger` | Notify Honeybadger on exceptions. |
+| `:unique` | Idempotent dedupe by `correlation_id` (requires storage). |
+
+Write your own — see [middleware.md](middleware.md).
+
+## Error handling
+
+A `perform` that raises:
+
+1. The message is rejected by default.
+2. `config.on_thread_error` is called with the exception.
+3. If `:exception_logger` middleware is in the chain, it logs with backtrace.
+4. If `:max_retry` is in the chain, it tracks retry count via RabbitMQ's `x-death` header and redirects to an error queue after N rejections.
+
+## Retries
+
+The built-in retry pattern uses RabbitMQ's dead-letter machinery:
+
+```ruby
+configure(
+  queue:       'orders',
+  exchange:    { name: 'orders', type: :topic, durable: true },
+  routing_key: 'order.*',
+  retry_queue: { delay: 5_000 },  # 5-second delay before retry
+  error_queue: 'orders.error'
+)
+use :max_retry, retries: 5, error_queue: 'orders.error'
+```
+
+On rejection:
+
+1. `max_retry` inspects `x-death` headers.
+2. If retries are below the limit, it re-publishes to the retry queue.
+3. After TTL, the retry queue dead-letters back to the original queue for another attempt.
+4. After N failures, the middleware routes to the error queue.
+
+## Worker assignment
+
+Assign a consumer to a named worker pool:
+
+```ruby
+configure(
+  queue:    'orders',
+  exchange: { name: 'orders', type: :topic },
+  process:  { name: :high_priority, threads: 10 }
+)
+```
+
+Then in the global config:
+
+```ruby
+Lepus.configure do |config|
+  config.worker(:high_priority) do |w|
+    w.pool_size = 20
+  end
+end
+```
+
+Consumers assigned to the same worker share a single subprocess.
+
+## Logging
+
+Inside `perform`, `logger` is the Lepus logger (tagged with the consumer class name):
+
+```ruby
+def perform(message)
+  logger.info("processing #{message.delivery_info.routing_key}")
+  # ...
+end
+```
+
+## Testing
+
+See [testing.md](testing.md) for the test-mode helpers.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,136 @@
+# Getting Started
+
+## Install
+
+```ruby
+# Gemfile
+gem 'lepus'
+```
+
+```bash
+bundle install
+```
+
+You'll also need a running RabbitMQ instance. For local dev:
+
+```bash
+docker run -d --rm -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+```
+
+## Configure
+
+```ruby
+# config/initializers/lepus.rb (Rails) or your bootstrap file
+Lepus.configure do |config|
+  config.rabbitmq_url    = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+  config.connection_name = 'my-service'
+end
+```
+
+See [configuration.md](configuration.md) for the full DSL.
+
+## Define a consumer
+
+```ruby
+# app/consumers/orders_consumer.rb
+class OrdersConsumer < Lepus::Consumer
+  configure(
+    queue:       'orders',
+    exchange:    { name: 'orders', type: :topic, durable: true },
+    routing_key: ['order.*']
+  )
+
+  use :json, symbolize_keys: true
+
+  def perform(message)
+    # message.payload       => the decoded JSON body (a hash, due to the :json middleware)
+    # message.delivery_info => exchange, routing_key, redelivered?
+    # message.metadata      => headers, content_type, correlation_id, etc.
+    Order.create!(message.payload)
+    :ack
+  end
+end
+```
+
+The `perform` method returns a symbol indicating disposition:
+
+- `:ack` — acknowledge; RabbitMQ removes the message.
+- `:reject` — reject; message is dropped (or routed to a dead-letter exchange if configured).
+- `:requeue` — reject and requeue for another delivery attempt.
+- `:nack` — negative-ack without requeue (similar to `:reject`).
+
+`ack!`, `reject!`, `requeue!`, `nack!` are also available as helper methods.
+
+## Define a producer
+
+```ruby
+# app/producers/orders_producer.rb
+class OrdersProducer < Lepus::Producer
+  configure(
+    exchange: { name: 'orders', type: :topic, durable: true },
+    publish:  { persistent: true }
+  )
+
+  use :json
+  use :correlation_id
+end
+```
+
+Publish:
+
+```ruby
+OrdersProducer.publish(
+  { order_id: 42, total: 99.99 },
+  routing_key: 'order.created'
+)
+```
+
+## Run
+
+### One-off (development)
+
+```bash
+bundle exec lepus start OrdersConsumer
+```
+
+Flags worth knowing:
+
+```bash
+bundle exec lepus start OrdersConsumer PaymentsConsumer \
+  --require_file config/environment.rb \
+  --debug
+```
+
+See [cli.md](cli.md).
+
+### As a long-running service
+
+In production, run `lepus start` with all your consumer classes (or auto-load them — see below) under your favorite process supervisor (systemd, Foreman, Kamal, Kubernetes).
+
+Auto-load consumers from a directory:
+
+```ruby
+Lepus.configure do |config|
+  config.consumers_directory = 'app/consumers'
+end
+```
+
+```bash
+bundle exec lepus start   # with no class args, starts all consumers from consumers_directory
+```
+
+## Monitor
+
+```bash
+bundle exec lepus web --port 9292
+```
+
+Visit http://localhost:9292 to see consumer status, throughput, and recent activity. See [web.md](web.md).
+
+## Next steps
+
+- [Consumers](consumers.md) — full consumer DSL, retries, error handling
+- [Producers](producers.md) — exchange config, publishing options, hooks
+- [Middleware](middleware.md) — built-in middlewares and writing your own
+- [Supervisor](supervisor.md) — process model, graceful shutdown, worker pools
+- [Rails integration](rails.md) — Railtie, executor wrapping

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,0 +1,240 @@
+# Middleware
+
+Lepus middlewares form a chain around each message — both for producers (around each publish) and consumers (around each delivery). Every middleware gets the message and the next app in the chain:
+
+```ruby
+class MyMiddleware < Lepus::Middleware
+  def initialize(option: nil)
+    @option = option
+  end
+
+  def call(message, app)
+    # pre-processing
+    new_message = message.mutate(payload: transform(message.payload))
+    # pass down the chain (and let the consumer/publisher actually run)
+    result = app.call(new_message)
+    # post-processing
+    result
+  end
+
+  private
+
+  def transform(payload) = payload
+end
+```
+
+## Registering
+
+### Per consumer / per producer
+
+```ruby
+class OrdersConsumer < Lepus::Consumer
+  use :json, symbolize_keys: true        # built-in by symbol
+  use :max_retry, retries: 5
+  use MyMiddleware, option: 'value'      # your own class
+end
+```
+
+### Globally
+
+```ruby
+Lepus.configure do |config|
+  config.consumer_middlewares do |chain|
+    chain.use :json, symbolize_keys: true
+    chain.use :exception_logger
+  end
+
+  config.producer_middlewares do |chain|
+    chain.use :json
+    chain.use :correlation_id
+    chain.use :instrumentation
+  end
+end
+```
+
+Global middlewares run **before** per-class middlewares.
+
+## Built-in consumer middlewares
+
+### `:json`
+
+Parse the payload from JSON.
+
+```ruby
+use :json, symbolize_keys: true, on_error: proc { :reject }
+```
+
+Options:
+
+- `symbolize_keys: true` — hash keys become symbols.
+- `on_error:` — a callable that takes the exception; its return becomes the disposition (default: `:reject`).
+
+### `:max_retry`
+
+Track retry count via RabbitMQ `x-death` headers and route to an error queue after N attempts.
+
+```ruby
+use :max_retry, retries: 5, error_queue: 'orders.error'
+```
+
+Requires the consumer's `configure` to declare a `retry_queue:` so requeued messages loop through a delay queue.
+
+### `:exception_logger`
+
+Catch exceptions from downstream middlewares/perform, log with backtrace, then re-raise (so higher-level error handling still sees the exception).
+
+```ruby
+use :exception_logger
+```
+
+### `:honeybadger`
+
+Notify Honeybadger on exceptions. Requires the `honeybadger` gem.
+
+```ruby
+use :honeybadger
+```
+
+### `:unique`
+
+Dedupe messages by `correlation_id`. Requires a storage backend (your code wires Redis or similar).
+
+```ruby
+use :unique, store: MyRedisStore
+```
+
+## Built-in producer middlewares
+
+### `:json`
+
+Serialize a hash payload as JSON; set `content_type` to `application/json`.
+
+```ruby
+use :json
+```
+
+### `:correlation_id`
+
+Auto-generate a UUID correlation id if one isn't already set on the message.
+
+```ruby
+use :correlation_id
+```
+
+### `:header`
+
+Add headers to every publish.
+
+```ruby
+use :header, 'X-Service', 'orders-api'
+use :header, 'X-Request-Id', -> { Current.request_id }
+```
+
+The value can be a static value or a callable.
+
+### `:instrumentation`
+
+Emit `ActiveSupport::Notifications` events before and after each publish. Event name: `publish.lepus`.
+
+```ruby
+use :instrumentation
+```
+
+Subscribe:
+
+```ruby
+ActiveSupport::Notifications.subscribe('publish.lepus') do |name, start, finish, id, payload|
+  puts "published to #{payload[:exchange]} in #{(finish - start) * 1000}ms"
+end
+```
+
+### `:unique`
+
+Drop duplicate publishes. Requires a storage backend.
+
+```ruby
+use :unique, store: MyRedisStore
+```
+
+## Writing your own
+
+### Consumer middleware
+
+```ruby
+class LogLevelMiddleware < Lepus::Middleware
+  def initialize(level: :info)
+    @level = level
+  end
+
+  def call(message, app)
+    Lepus.logger.public_send(@level, "Processing: #{message.payload.inspect}")
+    app.call(message)
+  end
+end
+
+class OrdersConsumer < Lepus::Consumer
+  use LogLevelMiddleware, level: :debug
+end
+```
+
+### Producer middleware
+
+Same interface. Typical use: decorate the message with metadata before it's published.
+
+```ruby
+class TenantScopingMiddleware < Lepus::Middleware
+  def call(message, app)
+    with_tenant = message.mutate(metadata: message.metadata.merge(headers: message.metadata[:headers].merge('X-Tenant-Id' => Current.tenant_id)))
+    app.call(with_tenant)
+  end
+end
+```
+
+### Mutating a message
+
+`message.mutate(**kwargs)` returns a new message with updated fields — payload, metadata, delivery_info. Don't mutate in place; build a new one and pass it down.
+
+```ruby
+app.call(message.mutate(payload: transformed_payload))
+```
+
+## Order of execution
+
+For a consumer:
+
+```
+incoming delivery
+  → global consumer middlewares (in config order)
+  → per-consumer middlewares (in class-file order)
+  → perform(message)
+  → each middleware unwinds (post-processing)
+  → disposition returned
+```
+
+For a producer:
+
+```
+publish(payload)
+  → per-producer middlewares
+  → global producer middlewares
+  → Bunny publish
+  → unwind
+```
+
+## Conditional middleware
+
+Middleware can decide not to call the next app — effectively short-circuiting:
+
+```ruby
+class SkipDuringMaintenanceMiddleware < Lepus::Middleware
+  def call(message, app)
+    if Feature.maintenance_mode?
+      Lepus.logger.warn('skipping publish during maintenance')
+      return  # do NOT call app.call(message)
+    end
+    app.call(message)
+  end
+end
+```
+
+For consumers, returning early means the consumer's `perform` never runs. The return value of `call` becomes the disposition.

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -1,0 +1,173 @@
+# Producers
+
+A producer publishes messages to an exchange. It's a subclass of `Lepus::Producer` with a `configure` call and whatever convenience methods you want on top.
+
+## Minimal example
+
+```ruby
+class OrdersProducer < Lepus::Producer
+  configure(
+    exchange: { name: 'orders', type: :topic, durable: true },
+    publish:  { persistent: true }
+  )
+
+  use :json
+  use :correlation_id
+end
+```
+
+Publish from anywhere in your app:
+
+```ruby
+OrdersProducer.publish(
+  { order_id: 42, total: 99.99 },
+  routing_key: 'order.created'
+)
+```
+
+## `configure` DSL
+
+```ruby
+configure(
+  exchange: { name: 'orders', type: :topic, durable: true },
+  publish:  { persistent: true, mandatory: false }
+)
+```
+
+| Key | Purpose |
+|-----|---------|
+| `exchange` | String (name only) or hash (`name`, `type`, `durable`, `auto_delete`). Auto-declared on first publish. |
+| `publish` | Default publish options merged into every `publish` call: `persistent`, `mandatory`, `content_type`, `expiration`, etc. |
+
+## Publishing
+
+```ruby
+OrdersProducer.publish(payload, routing_key: 'order.created')
+OrdersProducer.publish(payload, routing_key: 'order.paid', headers: { tenant_id: 123 })
+OrdersProducer.publish(payload, routing_key: 'order.created', expiration: 60_000)
+```
+
+All Bunny publish options are supported. Frequently useful:
+
+| Option | Purpose |
+|--------|---------|
+| `routing_key` | Routing key. |
+| `persistent` | Persist the message across RabbitMQ restarts. |
+| `headers` | Custom headers. |
+| `correlation_id` | RPC pattern correlation. Auto-set by `:correlation_id` middleware. |
+| `content_type` | MIME type. Auto-set to `application/json` by `:json` middleware. |
+| `expiration` | Per-message TTL in milliseconds. |
+| `mandatory` | Return the message if it can't be routed. |
+
+## Payload types
+
+- A Hash — pair with `:json` middleware to serialize.
+- A String — sent as-is.
+- Anything else — pair with a middleware that turns it into bytes.
+
+## Middleware
+
+```ruby
+class OrdersProducer < Lepus::Producer
+  use :json
+  use :correlation_id
+  use :instrumentation
+  use :header, 'X-Service', 'orders-api'
+end
+```
+
+Built-in producer middlewares:
+
+| Name | Purpose |
+|------|---------|
+| `:json` | Serialize a hash into JSON; sets `content_type`. |
+| `:correlation_id` | Auto-generate a UUID `correlation_id` if absent. |
+| `:header` | Add a static or dynamic header: `use :header, 'X-Foo', 'bar'`. |
+| `:instrumentation` | Emit `ActiveSupport::Notifications` events around each publish. |
+| `:unique` | Reject duplicate publishes (by correlation id — needs external storage). |
+
+Write your own — see [middleware.md](middleware.md).
+
+## Convenience class methods
+
+Wrap `publish` with domain-specific signatures:
+
+```ruby
+class OrdersProducer < Lepus::Producer
+  configure(exchange: { name: 'orders', type: :topic, durable: true })
+  use :json
+  use :correlation_id
+
+  def self.order_created(order)
+    publish(
+      { order_id: order.id, total: order.total, created_at: order.created_at },
+      routing_key: 'order.created'
+    )
+  end
+
+  def self.order_shipped(order)
+    publish(
+      { order_id: order.id, shipped_at: order.shipped_at },
+      routing_key: 'order.shipped'
+    )
+  end
+end
+
+# In your code:
+OrdersProducer.order_created(order)
+```
+
+## Connection pooling
+
+Producers share a single connection pool across the process:
+
+```ruby
+Lepus.configure do |config|
+  config.producer do |p|
+    p.pool_size    = 5
+    p.pool_timeout = 5.0
+  end
+end
+```
+
+## Enable / disable publishing
+
+Useful when you want to disable side effects in tests or a specific environment.
+
+```ruby
+# Globally
+Lepus::Producers.disable!
+Lepus::Producers.enabled?(OrdersProducer)  # => false
+
+# By producer class
+Lepus::Producers.disable!(OrdersProducer)
+
+# By exchange name
+Lepus::Producers.disable!('orders')
+
+# Block-scoped
+Lepus::Producers.without_publishing do
+  OrdersProducer.publish(...)  # no-op
+end
+
+Lepus::Producers.with_publishing do
+  OrdersProducer.publish(...)  # forced through even if disabled
+end
+```
+
+## Error handling
+
+A publish can fail for many reasons — connection down, channel closed, etc. By default, Bunny retries with exponential backoff within `recovery_attempts`. For anything beyond that, you catch and handle it:
+
+```ruby
+begin
+  OrdersProducer.order_created(order)
+rescue Bunny::Exception => e
+  Rails.logger.error("publish failed: #{e.message}")
+  # queue for later retry, fall back to a DB outbox, etc.
+end
+```
+
+## Testing
+
+See [testing.md](testing.md) — there's a `Lepus::Testing.producer_messages(ProducerClass)` helper that captures publishes in-memory.

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -1,0 +1,161 @@
+# Rails Integration
+
+When Rails is loaded, Lepus's Railtie wires up sensible defaults. No initializer is strictly required.
+
+## What the Railtie does
+
+- Sets `config.logger = Rails.logger` (unless you've already set one).
+- Sets `config.app_executor = Rails.application.executor` — every consumer `perform` runs inside the Rails executor, which means:
+  - Autoloading works (Zeitwerk is active).
+  - Query cache is cleared after each message.
+  - Connection cleanup runs after each message.
+  - Reloading works in development.
+- Subscribes the log subscriber for friendly production log lines.
+- Integrates with `Rails.error` — unhandled exceptions are reported there.
+
+## Overriding
+
+```ruby
+# config/initializers/lepus.rb
+Lepus.configure do |config|
+  config.rabbitmq_url    = ENV.fetch('RABBITMQ_URL')
+  config.connection_name = 'my-service'
+
+  # Override the defaults:
+  config.logger       = MyLogger.new
+  config.app_executor = nil   # disable executor wrapping entirely
+
+  config.consumers_directory = 'app/consumers'
+
+  config.worker(:default) do |w|
+    w.pool_size = 5
+    w.before_fork { ActiveRecord::Base.connection_handler.clear_all_connections! }
+    w.after_fork  { ActiveRecord::Base.establish_connection }
+  end
+end
+```
+
+## Defining consumers and producers
+
+Put them in `app/consumers/` and `app/producers/`. With `config.consumers_directory = 'app/consumers'`, `lepus start` with no arguments auto-loads all of them.
+
+```ruby
+# app/consumers/orders_consumer.rb
+class OrdersConsumer < Lepus::Consumer
+  configure(
+    queue:    'orders',
+    exchange: { name: 'orders', type: :topic, durable: true },
+    routing_key: 'order.*'
+  )
+  use :json, symbolize_keys: true
+
+  def perform(message)
+    Order.create!(message.payload)
+    :ack
+  end
+end
+```
+
+```ruby
+# app/producers/orders_producer.rb
+class OrdersProducer < Lepus::Producer
+  configure(exchange: { name: 'orders', type: :topic, durable: true })
+  use :json
+  use :correlation_id
+end
+```
+
+## Running alongside a Rails web app
+
+```bash
+# Terminal 1 — web
+bin/rails server
+
+# Terminal 2 — consumers
+bundle exec lepus start --require_file config/environment.rb
+```
+
+Or use Foreman:
+
+```
+# Procfile
+web:    bin/rails server
+worker: bundle exec lepus start --require_file config/environment.rb
+```
+
+## The Puma plugin
+
+For apps that want consumers running inside the same Puma process (development convenience, or small-scale production where you don't want another service):
+
+```ruby
+# config/puma.rb
+plugin :lepus
+```
+
+The plugin forks consumer workers as Puma's cluster workers would, tying their lifecycle to Puma's.
+
+**Caution:** running consumers inside Puma means process restarts on deploy take longer (waiting for in-flight messages) and you can't scale consumers independently of web requests. For non-trivial workloads, run them as a separate service.
+
+## Mounting the web dashboard
+
+```ruby
+# config/routes.rb
+require 'lepus/web'
+
+authenticate :user, ->(u) { u.admin? } do
+  mount Lepus::Web::App, at: '/lepus'
+end
+```
+
+See [web.md](web.md).
+
+## Testing
+
+```ruby
+# spec/rails_helper.rb (or spec/spec_helper.rb)
+require 'lepus/testing'
+
+RSpec.configure do |config|
+  config.before(:each) { Lepus::Testing.enable!; Lepus::Testing.reset! }
+end
+```
+
+See [testing.md](testing.md).
+
+## Active Record gotchas
+
+Since `app_executor` is set to `Rails.application.executor`, Active Record connection management is handled per message — no manual `clear_active_connections!` needed.
+
+For worker subprocesses, the `before_fork` / `after_fork` hooks close and reopen connections cleanly:
+
+```ruby
+Lepus.configure do |config|
+  config.worker(:default) do |w|
+    w.before_fork { ActiveRecord::Base.connection_handler.clear_all_connections! }
+    w.after_fork  { ActiveRecord::Base.establish_connection }
+  end
+end
+```
+
+Without these hooks, all children inherit the same database socket and things go badly fast.
+
+## Exception reporting
+
+Lepus's Rails integration reports unhandled exceptions via `Rails.error`:
+
+```ruby
+# config/application.rb or an initializer
+Rails.error.subscribe do |exception, handled:, severity:, context:, source:|
+  Honeybadger.notify(exception, context: context) if source == 'lepus'
+end
+```
+
+Or use the `:honeybadger` middleware directly on your consumers — see [middleware.md](middleware.md).
+
+## Zeitwerk
+
+Consumer and producer classes are autoloaded by Zeitwerk like any other Rails class. `app/consumers/orders_consumer.rb` → `OrdersConsumer`, namespaced with the usual folder-to-module rules.
+
+## Generators
+
+None at the moment. Create consumer and producer files by hand (or your editor's snippet of choice).

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -1,0 +1,112 @@
+# Supervisor
+
+The supervisor is the parent process when you run `lepus start`. It forks workers, monitors them, and handles signals.
+
+## Process model
+
+```
+Supervisor (pid = $$)
+├── Worker[:default]        pid = 1001
+│   ├── Thread OrdersConsumer
+│   └── Thread OrdersConsumer
+└── Worker[:high_priority]  pid = 1002
+    └── Thread PaymentsConsumer
+```
+
+- **One worker per named pool.** Consumers with `process.name = :default` share a worker; consumers with `process.name = :high_priority` share a different one. Unnamed consumers default to `:default`.
+- **Multiple threads per worker.** Each worker runs a thread pool sized by `config.worker(:name).pool_size`.
+- **One channel per consumer.** Each consumer gets its own Bunny channel to avoid cross-consumer interference.
+
+Fork boundaries matter because child processes inherit open file descriptors, sockets, and DB connections. See the `before_fork` / `after_fork` hooks below.
+
+## Fork hooks
+
+```ruby
+Lepus.configure do |config|
+  config.worker(:default) do |w|
+    # Runs in the SUPERVISOR just before fork()
+    w.before_fork do
+      ActiveRecord::Base.connection_handler.clear_all_connections!
+      Redis.current.disconnect!
+    end
+
+    # Runs in the CHILD after fork()
+    w.after_fork do
+      ActiveRecord::Base.establish_connection
+      Redis.current = Redis.new
+      SecureRandom.hex(4)  # implicit reseed
+    end
+  end
+end
+```
+
+The classic pattern: close long-lived connections in `before_fork`, reopen them in `after_fork`. Otherwise all children end up sharing the same socket.
+
+## Signals
+
+| Signal | Supervisor response |
+|--------|---------------------|
+| `SIGTERM` | Graceful shutdown — see below. |
+| `SIGINT` | Graceful shutdown (same as SIGTERM). |
+| `SIGQUIT` | Graceful shutdown, slightly more aggressive. |
+| `SIGTTIN` | Dump thread backtraces of every worker (debugging). |
+| `SIGUSR1` | Reopen log files (useful for logrotate). |
+
+Child workers respond to the same signals, but normally the supervisor handles signals and forwards the shutdown to children.
+
+## Graceful shutdown
+
+1. Supervisor writes a shutdown message to each worker's pipe.
+2. Each worker stops accepting new messages (`basic.cancel` on its channels).
+3. In-flight `perform` calls are allowed to finish.
+4. Workers close connections and exit with code 0.
+5. If a worker takes longer than `shutdown_timeout` (default 5 seconds per message, tuned via consumer `channel.shutdown_timeout`), it's killed with `SIGKILL`.
+6. Supervisor exits.
+
+Rule of thumb for deploy scripts: send SIGTERM, wait at least `pool_size × average_message_duration + 5 seconds`, then the supervisor should have exited cleanly.
+
+## Worker crash recovery
+
+If a worker exits unexpectedly (raised exception outside a `perform` call, OOM, killed by OOM killer):
+
+1. Supervisor detects the pipe close.
+2. Logs the exit status.
+3. Forks a new worker using the same `before_fork` / `after_fork` hooks.
+4. Worker re-declares its queues and resumes consuming.
+
+Within a `perform`, exceptions are caught and routed to `on_thread_error`; the worker is not restarted for those. Only crashes at the worker level (outside message handling) trigger a restart.
+
+## Heartbeats and the process registry
+
+Each worker (and the supervisor itself) emits heartbeats to the process registry:
+
+```ruby
+config.process_heartbeat_interval = 60     # seconds
+config.process_alive_threshold    = 5 * 60 # seconds
+```
+
+The web dashboard reads from this registry to display process status. Processes whose last heartbeat is older than `process_alive_threshold` are considered dead and hidden from the UI (but kept briefly so transient restarts don't flash).
+
+## Pidfile
+
+```bash
+bundle exec lepus start --pidfile /var/run/lepus.pid
+```
+
+Written by the supervisor at boot, removed at graceful shutdown. If the file exists when lepus starts, the supervisor checks if the PID is alive; if so, it exits (don't run two supervisors). If not, it overwrites.
+
+## Running under a process manager
+
+- **systemd:** `ExecStart=/path/to/bundle exec lepus start --pidfile /run/lepus.pid`, `KillSignal=SIGTERM`, `TimeoutStopSec=60`.
+- **Foreman / Procfile:** `worker: bundle exec lepus start`. No pidfile needed.
+- **Kubernetes:** set a `preStop` lifecycle hook to send SIGTERM, and tune `terminationGracePeriodSeconds` to be larger than your longest `perform`.
+
+## Debugging a stuck worker
+
+Send SIGTTIN:
+
+```bash
+kill -TTIN <worker-pid>
+```
+
+The worker prints thread backtraces to the log. Useful when you suspect a deadlock or a `perform` stuck on a slow network call.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,141 @@
+# Testing
+
+Lepus ships a test-mode module that captures publishes and runs consumer `perform` methods synchronously — no RabbitMQ connection required.
+
+## Enabling
+
+```ruby
+# spec/spec_helper.rb (RSpec)
+require 'lepus/testing'
+
+RSpec.configure do |config|
+  config.before(:each) { Lepus::Testing.enable! }
+  config.after(:each)  { Lepus::Testing.reset! }
+end
+```
+
+Once enabled:
+
+- Publishes don't hit RabbitMQ. They're captured in an in-memory buffer keyed by producer class.
+- Consumer handling is synchronous when invoked through `Lepus::Testing.consumer_perform`.
+
+## Testing a consumer
+
+```ruby
+describe OrdersConsumer do
+  it 'creates an order' do
+    result = Lepus::Testing.consumer_perform(
+      OrdersConsumer,
+      { order_id: 42, total: 99.99 }
+    )
+
+    expect(result).to eq(:ack)
+    expect(Order.find(42).total).to eq(99.99)
+  end
+
+  it 'rejects invalid payloads' do
+    result = Lepus::Testing.consumer_perform(OrdersConsumer, { bad: 'data' })
+    expect(result).to eq(:reject)
+  end
+
+  it 'sets delivery info and metadata' do
+    result = Lepus::Testing.consumer_perform(
+      OrdersConsumer,
+      { order_id: 7 },
+      delivery_info: { routing_key: 'order.created' },
+      metadata:      { correlation_id: 'abc-123' }
+    )
+    expect(result).to eq(:ack)
+  end
+end
+```
+
+`consumer_perform` signature:
+
+```ruby
+Lepus::Testing.consumer_perform(
+  ConsumerClass,
+  payload,
+  delivery_info: {},
+  metadata: {}
+)
+```
+
+It builds a `Lepus::Message`, runs the full middleware chain (including global middlewares), and returns the disposition symbol.
+
+## Testing a producer
+
+```ruby
+describe OrdersProducer do
+  it 'publishes the order' do
+    order = Order.create!(id: 42, total: 99.99)
+    OrdersProducer.order_created(order)
+
+    messages = Lepus::Testing.producer_messages(OrdersProducer)
+    expect(messages.size).to eq(1)
+    expect(messages[0][:payload]).to include(order_id: 42)
+    expect(messages[0][:routing_key]).to eq('order.created')
+  end
+
+  it 'runs through middleware' do
+    OrdersProducer.publish({ foo: 'bar' }, routing_key: 'x')
+
+    msg = Lepus::Testing.producer_messages(OrdersProducer).last
+    expect(msg[:metadata][:correlation_id]).to be_present  # set by :correlation_id middleware
+    expect(msg[:metadata][:content_type]).to eq('application/json')
+  end
+end
+```
+
+`producer_messages(ProducerClass)` returns an array of hashes with `:payload`, `:routing_key`, `:delivery_info`, `:metadata`.
+
+## RSpec matchers
+
+```ruby
+# spec/spec_helper.rb
+require 'lepus/testing/rspec_matchers'
+```
+
+Then:
+
+```ruby
+expect { OrdersProducer.order_created(order) }
+  .to have_published_message(OrdersProducer)
+  .with_payload(include(order_id: order.id))
+  .to_routing_key('order.created')
+```
+
+## Testing middleware in isolation
+
+Middlewares are plain Ruby objects with a `call(message, app)` method. Unit-test them directly:
+
+```ruby
+describe LogLevelMiddleware do
+  it 'logs before calling down the chain' do
+    middleware = LogLevelMiddleware.new(level: :debug)
+    message   = Lepus::Testing::MessageBuilder.build(payload: { x: 1 })
+    captured  = nil
+
+    allow(Lepus.logger).to receive(:debug) { |msg| captured = msg }
+    middleware.call(message, ->(m) { :ack })
+
+    expect(captured).to include('Processing:')
+  end
+end
+```
+
+`Lepus::Testing::MessageBuilder.build(**kwargs)` builds a realistic `Lepus::Message` for unit tests.
+
+## Resetting between tests
+
+`Lepus::Testing.reset!` clears captured publishes. In shared setup:
+
+```ruby
+RSpec.configure do |config|
+  config.before(:each) { Lepus::Testing.enable!; Lepus::Testing.reset! }
+end
+```
+
+## When you do need a real RabbitMQ
+
+Integration tests that exercise the full round-trip (publish → RabbitMQ → consume) benefit from a real broker. Use `docker run rabbitmq:3-management` or your test infra's existing one, and skip `Lepus::Testing.enable!` for those specs.

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,0 +1,83 @@
+# Web Dashboard
+
+Lepus ships a Rack-based monitoring UI showing consumer status, throughput, and recent activity.
+
+## Running it standalone
+
+```bash
+bundle exec lepus web --port 9292 --host 0.0.0.0
+```
+
+Visit http://localhost:9292.
+
+## Mounting in Rails
+
+```ruby
+# config/routes.rb
+require 'lepus/web'
+
+authenticate :user, ->(u) { u.admin? } do
+  mount Lepus::Web::App, at: '/lepus'
+end
+```
+
+Or with Devise:
+
+```ruby
+authenticate :admin_user do
+  mount Lepus::Web::App, at: '/admin/lepus'
+end
+```
+
+**Important:** the dashboard has no built-in auth. Wrap it with whatever your app already uses.
+
+## What it shows
+
+- **Supervisors.** Every running `lepus start` process.
+- **Workers.** Subprocesses per supervisor, with their named pool and PID.
+- **Consumers.** Per-consumer message counts (processed, rejected, errored), queue names, routing keys.
+- **Exchanges & queues.** RabbitMQ topology as seen by the gem.
+- **Recent activity.** Last N messages — timestamps, routing keys, dispositions.
+
+## Registry backend
+
+The dashboard reads from the process registry, configured at `Lepus.configure`:
+
+```ruby
+config.process_registry_backend = :file      # single-host
+# or
+config.process_registry_backend = :rabbitmq  # multi-host
+```
+
+- `:file` — metadata stored under `/tmp/lepus/...`. Works out of the box but only for a single host.
+- `:rabbitmq` — metadata stored in RabbitMQ itself. Multiple `lepus start` processes across multiple hosts show up in one dashboard.
+
+For `:rabbitmq`, also set:
+
+```ruby
+config.management_api_url = 'http://rabbitmq:15672'
+```
+
+## Heartbeats
+
+Each worker heartbeats into the registry every `config.process_heartbeat_interval` (default 60 seconds). Processes are considered "alive" if their last heartbeat is within `config.process_alive_threshold` (default 5 minutes).
+
+## API endpoints
+
+The dashboard exposes a minimal read-only JSON API at `/api/...` — the UI is a single-page app that consumes it. You can also consume the API directly for custom dashboards or alerting.
+
+Endpoints include (subject to change):
+
+- `GET /api/processes` — all tracked processes
+- `GET /api/consumers` — all registered consumers with counts
+- `GET /api/queues` — queue metadata from the RabbitMQ management API (if `management_api_url` is set)
+
+## Prometheus metrics
+
+When `prometheus_exporter` is in your Gemfile and the appropriate middleware is in the chain, Lepus emits counters and histograms for message processing. Point Prometheus at the standard exporter endpoint.
+
+## Operating in production
+
+- Put the dashboard behind your existing auth layer (OAuth proxy, Rails authentication, Basic auth).
+- Use `:rabbitmq` registry backend for multi-node visibility.
+- Retain logs separately — the dashboard is for live state, not audit trails.


### PR DESCRIPTION
## Summary

Adds an 11-file documentation set under `docs/`:

- **Entry points**: `README.md`, `getting-started.md`, `configuration.md`
- **Core concepts**: `consumers.md`, `producers.md`, `middleware.md`
- **Runtime**: `cli.md`, `supervisor.md`, `web.md`
- **Ecosystem**: `testing.md`, `rails.md`

Covers the full consumer/producer DSL, built-in middlewares, supervisor process model (fork hooks, signal handling, graceful shutdown), the CLI (`lepus start`, `lepus web`), and the web dashboard. Includes Rails-specific guidance (Railtie, executor wrapping, Puma plugin).

## Test plan

- [ ] Skim `docs/README.md` as a navigation entry point
- [ ] Verify consumer/producer DSL examples match the current API
- [ ] Verify middleware list in `middleware.md` matches what ships in the gem
- [ ] Verify CLI flags in `cli.md` match what `bundle exec lepus start --help` shows
- [ ] Verify the signal table in `supervisor.md` matches actual behavior