### PR TITLE
fix: inherit middleware chain from superclass in consumers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lepus (0.1.0)
+    lepus (0.1.1)
       base64
       bunny
       concurrent-ruby
@@ -14,12 +14,13 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    amq-protocol (2.5.1)
+    amq-protocol (2.7.0)
     ast (2.4.2)
     base64 (0.3.0)
     bigdecimal (3.1.8)
-    bunny (2.24.0)
-      amq-protocol (~> 2.3)
+    bunny (3.0.0)
+      amq-protocol (~> 2.7)
+      logger (~> 1, >= 1.7)
       sorted_set (~> 1, >= 1.0.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
@@ -37,6 +38,7 @@ GEM
     json (2.7.5)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    logger (1.7.0)
     method_source (1.1.0)
     multi_json (1.15.0)
     parallel (1.26.3)

--- a/gemfiles/Gemfile.rails-5.2.lock
+++ b/gemfiles/Gemfile.rails-5.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lepus (0.1.0)
+    lepus (0.1.1)
       base64
       bunny
       concurrent-ruby

--- a/gemfiles/Gemfile.rails-6.1.lock
+++ b/gemfiles/Gemfile.rails-6.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lepus (0.1.0)
+    lepus (0.1.1)
       base64
       bunny
       concurrent-ruby
@@ -73,7 +73,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    amq-protocol (2.7.0)
+    amq-protocol (2.8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.1)

--- a/gemfiles/Gemfile.rails-7.2.lock
+++ b/gemfiles/Gemfile.rails-7.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lepus (0.1.0)
+    lepus (0.1.1)
       base64
       bunny
       concurrent-ruby

--- a/gemfiles/Gemfile.rails-8.0.lock
+++ b/gemfiles/Gemfile.rails-8.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    lepus (0.1.0)
+    lepus (0.1.1)
       base64
       bunny
       concurrent-ruby

--- a/lib/lepus/consumer.rb
+++ b/lib/lepus/consumer.rb
@@ -30,9 +30,17 @@ module Lepus
       end
 
       # Returns the middleware chain for this consumer.
+      # Inherits middlewares registered on superclasses so abstract base consumers
+      # can declare shared middlewares with `use` and have them apply to subclasses.
       # @return [Lepus::Consumers::MiddlewareChain]
       def middleware_chain
-        @middleware_chain ||= Consumers::MiddlewareChain.new
+        @middleware_chain ||= begin
+          chain = Consumers::MiddlewareChain.new
+          if superclass.respond_to?(:middleware_chain)
+            superclass.middleware_chain.middlewares.each { |m| chain.middlewares << m }
+          end
+          chain
+        end
       end
 
       # Registers a middleware to this consumer's chain.

--- a/lib/lepus/version.rb
+++ b/lib/lepus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lepus
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lepus/consumer_spec.rb
+++ b/spec/lepus/consumer_spec.rb
@@ -94,6 +94,43 @@ RSpec.describe Lepus::Consumer do
     end
   end
 
+  describe ".middleware_chain" do
+    it "inherits middlewares from the superclass" do
+      middleware_class = Class.new(Lepus::Middleware) do
+        def call(message, app)
+          app.call(message)
+        end
+      end
+
+      parent = Class.new(described_class) do
+        self.abstract_class = true
+      end
+      parent.use(middleware_class)
+
+      child = Class.new(parent)
+
+      expect(child.middleware_chain.middlewares.map(&:class)).to include(middleware_class)
+    end
+
+    it "does not mutate the superclass chain when subclasses register middlewares" do
+      middleware_class = Class.new(Lepus::Middleware) do
+        def call(message, app)
+          app.call(message)
+        end
+      end
+
+      parent = Class.new(described_class) do
+        self.abstract_class = true
+      end
+
+      child = Class.new(parent)
+      child.use(middleware_class)
+
+      expect(parent.middleware_chain.middlewares).to be_empty
+      expect(child.middleware_chain.middlewares.map(&:class)).to include(middleware_class)
+    end
+  end
+
   describe "#perform" do
     it "raises a not implemented error" do
       expect { instance.perform(message) }.to raise_error(


### PR DESCRIPTION
## Summary
- Middlewares registered with `use` on an abstract base consumer (e.g. `ApplicationConsumer`) were silently dropped on subclasses, because `Lepus::Consumer.middleware_chain` lazily initialized a fresh `@middleware_chain` per class without consulting the superclass.
- Subclasses now copy the parent's middlewares on first access, so shared middlewares declared on a base consumer propagate to descendants. Children can still register their own middlewares without mutating the parent's chain.
- Bumps patch version to `0.1.1` and refreshes pinned `Gemfile.lock` files (root + `gemfiles/Gemfile.rails-{5.2,6.1,7.2,8.0}.lock`).

## Test plan
- [x] `bundle exec rspec spec/lepus/consumer_spec.rb` — new specs cover inheritance + isolation between parent/child chains.
- [x] `bundle exec rspec` — full suite (774 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)